### PR TITLE
Plural instead of singular labels for no results.

### DIFF
--- a/wagtailmodelchooser/templates/wagtailmodelchooser/results.html
+++ b/wagtailmodelchooser/templates/wagtailmodelchooser/results.html
@@ -6,9 +6,9 @@
 		{% if not object_list %}
 			<div class="nice-padding" style="margin-top:30px;">
 				{% if is_searching %}
-					<p>No {{ opts.verbose_name }} found matching your search.</p>
+					<p>No {{ opts.verbose_name_plural }} found matching your search.</p>
 				{% else %}
-					<p>There are no {{ opts.verbose_name }}.</p>
+					<p>There are no {{ opts.verbose_name_plural }}.</p>
 				{% endif %}
 			</div>
 		{% else %}


### PR DESCRIPTION
"No books found." instead of "No book found."
"There are no books." instead of "There are no book."